### PR TITLE
[Feat] Allow people to use Docker instead of building.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM alpine:3.13.5
+RUN apk add --no-cache \
+    make \ 
+    gcc \
+    cmake \
+    git \
+    g++ \
+    pkgconfig \ 
+    build-base \
+    cairo-dev \
+    cairo \
+    cairo-tools \
+    graphicsmagick-dev \
+    openssl-dev \
+    boost-dev \
+    jpeg-dev \
+    xz-dev \
+    tiff-dev \
+    libpng-dev
+WORKDIR /opt
+RUN git clone -b master --single-branch --recurse-submodules https://github.com/cpp-io2d/P0267_RefImpl
+# TODO (davidnet) This should be cherrypicking but does not work in the repo.
+RUN wget -q "https://raw.githubusercontent.com/cpp-io2d/P0267_RefImpl/3100528b316167e94cf932c7a271467fedda26c1/P0267_RefImpl/Tests/CMakeLists.txt" \
+    -O P0267_RefImpl/P0267_RefImpl/Tests/CMakeLists.txt && \
+    cd P0267_RefImpl/P0267_RefImpl/Samples/svg/external/svgpp && \
+    git checkout master 
+RUN cd P0267_RefImpl && \
+    mkdir Debug && \
+    cd Debug && \
+    cmake --config Debug "-DCMAKE_BUILD_TYPE=Debug" .. && \
+    cmake --build . && \
+    make install
+# TODO (davidnet) Maybe set-up for a release?
+RUN git clone https://github.com/jdgalviss/osm-route-planner.git --recurse-submodules
+RUN cd osm-route-planner && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make
+WORKDIR /opt/osm-route-planner/build
+CMD ["./OSM_A_star_search"]

--- a/README.md
+++ b/README.md
@@ -54,8 +54,23 @@ or with SSH:
 git clone git@github.com:jdgalviss/osm-route-planner.git --recurse-submodules
 ```
 
+## Using Docker
+There is an associated `Dockerfile` that you can use to reference build instrucions (based on an image of alpine), and do routing without 2d rendering.
 
+## Building using Dockerfile
+You can use either Docker or Podman
 
+```bash
+$ docker build -t jdgalviss/osm-route-planner .
+```
+
+## Running using Dockerfile
+Either map your own osm file or use the one provided in the repo.
+```bash
+$ docker run -it jdgalviss/osm-route-planner 
+```
+
+Make sure you enable the `-it` flag so the program can read your inputs from a valid tty session and keyboard strokes.
 
 ## Compiling and Running
 


### PR DESCRIPTION
Adding a Dockerfile to simplify source code building. Let me know what you think.

Also, do you think is possible to not render, but to create an svg file from io2d I tried to add changes, but surface and type documentation of the library seems hard to me.

If that is done, then we have a happy containerized tool that can be more easy deployed.

Important changes:

* Cherry-pick to read png16.h in the P0267 lib implementation,
* Allow svg to be picked out from master.  